### PR TITLE
Ensure beanstalk connection is closed when tool finishes

### DIFF
--- a/bin/azuki
+++ b/bin/azuki
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import beanstalkc
+import contextlib
 import docopt
 import datetime
 import json
@@ -73,15 +74,17 @@ Options:
 """
 
     opts = docopt.docopt(usage)
-    bs = beanstalkc.Connection(opts['--host'] or 'localhost', int(opts['--port'] or 11300))
-    for command in commands:
-        if opts[command]:
-            try:
-                commands[command](bs, opts)
-            except beanstalkc.CommandFailed as e:
-                command, error, _ = e.args
-                sys.stderr.write("%s failed: %s\n" % (command, error))
-                sys.exit(1)
+    host = opts['--host'] or 'localhost'
+    port = int(opts['--port'] or 11300)
+    with contextlib.closing(beanstalkc.Connection(host, port)) as bs:
+        for command in commands:
+            if opts[command]:
+                try:
+                    commands[command](bs, opts)
+                except beanstalkc.CommandFailed as e:
+                    command, error, _ = e.args
+                    sys.stderr.write("%s failed: %s\n" % (command, error))
+                    sys.exit(1)
 
 @command
 def tubes(bs, opts):

--- a/bin/azuki
+++ b/bin/azuki
@@ -144,7 +144,12 @@ Commands:
         timeout: %(job-timeouts)d""" % stats
 
 def tube_stats(bs, tube):
-    stats = bs.stats_tube(tube)
+    # Defaults for older version of beanstalkd that don't (always) expose these
+    # variables, especially on a clean start
+    stats = {
+        'cmd-delete': '?',
+    }
+    stats.update(bs.stats_tube(tube))
     name = stats['name']
     if stats['pause-time-left']:
         name += ' (paused until %s)' % (datetime.datetime.now() + datetime.timedelta(0, stats['pause-time-left'])).strftime('%Y-%m-%d %H:%M:%S')
@@ -161,7 +166,7 @@ Jobs:
     Urgent:      %(current-jobs-urgent)d
     Reserved:    %(current-jobs-reserved)d
     Buried:      %(current-jobs-buried)d
-    Deleted:     %(cmd-delete)d
+    Deleted:     %(cmd-delete)s
     Total:       %(total-jobs)d""" % stats
 
 def job_stats(bs, job):

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,6 @@ setup(name = "azuki",
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
-      ]
+      ],
+      install_requires=["whelk>=2.4", "docopt>=0.5.0", "PyYAML>=3.10"],
 )


### PR DESCRIPTION
This change ensures that `bs.close()` is always called on the connection.

This makes the code for Python 2.6+ due to using the with statement.
